### PR TITLE
fix to get rid of deprecated warning for nullable string passed in special functions

### DIFF
--- a/common.php
+++ b/common.php
@@ -11,7 +11,7 @@ date_default_timezone_set('America/Montreal');
 
 function escape($html)
 {
-    return htmlspecialchars($html, ENT_QUOTES | ENT_SUBSTITUTE, "UTF-8");
+    return htmlspecialchars($html ?? '', ENT_QUOTES | ENT_SUBSTITUTE, "UTF-8");
 }
 
 function maybe_session_start()


### PR DESCRIPTION
added null coalescent operator to htmlspecialchars in escape function from common.php