### PR TITLE
Fix/announcements

### DIFF
--- a/public/announcements.php
+++ b/public/announcements.php
@@ -19,10 +19,9 @@ if (isset($_POST['submit']) && get_current_role() == "admin") {
     } catch (PDOException $error) {
         echo "<br>" . $error->getMessage();
     }
-} elseif (get_current_role() != "admin") {
+} elseif (isset($_POST['submit']) && get_current_role() != "admin") {
     echo "Invalid access, you are not an admin.";
 }
-
 ?>
 
 <?php include "templates/header.php"; ?>


### PR DESCRIPTION
When users who were not admin went on announcement page it always displayed the error message that should only appear if they illegally tried to post an announcement.

now it does show unless they try to create an announcement